### PR TITLE
Sync scope-name with ballerinalang/plugin-vscode#3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
 # Ballerina plugin for Atom
 
-## What is Ballerina
+## What is Ballerina?
 
-ballerina is a general purpose, concurrent and strongly typed
+Ballerina is a general purpose, concurrent and strongly typed
 programming language with both textual and graphical syntaxes.
 
-for more info: http://ballerinalang.org/
+For more info, visit http://ballerinalang.org/
 
 ## Overview
 
-This package includes the following functionality to ballerina(.bal) files in Atom.:
+This package adds the following features to Ballerina (`.bal`) files in Atom:
 - Syntax highlighting
 - Snippets
-- Syntax parse
-- Auto suggestions for system packages
+- Syntax parsing
+- Auto-suggestions for system packages
 
 ## Installing the plugin to Atom
 
 ### Installing via Install tab
-1. Open up the Settings View (Cmd+, in Mac or Ctrl+, for Windows/Linux)
-2. Click on the "Install" tab and type "language-ballerina" into the box under Install Packages
-3. Resulting packages will come up with an "Install" button
-4. Clicking install will download the package and install it
-5. Your editor will now have the functionality that the package provides
+
+1. Open up the **Settings View** by pressing <kbd>Cmd/Ctrl</kbd> + <kbd>,</kbd>
+2. Click on the **Install** tab
+3. Type `language-ballerina` in the box under **Install Packages**
+4. Resulting packages will come up with an **Install** button
+5. Clicking **Install** will download the package and install it
+6. Your editor will now have the functionality that the package provides
 
 ### Installing via zip
 
 1. Download zip: https://github.com/ballerinalang/plugin-atom/releases
 2. Unzip the folder
 3. Navigate into the folder
-4. execute command "apm install"
-5. execute command "apm link"
-6. reload atom application
+4. Execute command `apm install`
+5. Execute command `apm link`
+6. Restart Atom if the application is running
 
 ## How to contribute
 
@@ -40,7 +42,7 @@ to discuss the issue or feature that you are contributing to.
 
 ## License
 
-Ballerina atom plugin source is available under the Apache 2.0 License.
+Ballerina Atom plugin source is available under the Apache 2.0 License.
 
 ## Copyright
 

--- a/grammars/ballerina.cson
+++ b/grammars/ballerina.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.bal'
+'scopeName': 'source.ballerina'
 'name': 'Ballerina'
 'fileTypes': [
     'bal'

--- a/lib/atomAutocompleteProvider.js
+++ b/lib/atomAutocompleteProvider.js
@@ -9,8 +9,8 @@ export class AtomAutocompleteProvider {
     constructor(classLoader) {
         this.classLoader = classLoader;
         // settings for autocomplete-plus
-        this.selector = '.source.bal';
-        this.disableForSelector = '.source.bal .comment';
+        this.selector = '.source.ballerina';
+        this.disableForSelector = '.source.ballerina .comment';
     }
 
     configure(config) {

--- a/settings/language-ballerina.cson
+++ b/settings/language-ballerina.cson
@@ -1,4 +1,4 @@
-'.source.bal':
+'.source.ballerina':
   'editor':
     'commentStart': '// '
     'foldEndPattern': '^\\s*(\\}|// \\}\\}\\}$)'

--- a/snippets/language-ballerina.cson
+++ b/snippets/language-ballerina.cson
@@ -1,4 +1,4 @@
-'.source.bal':
+'.source.ballerina':
   'BasePath':
     'prefix': 'ba'
     'body': '@BasePath (${1:"/"})'


### PR DESCRIPTION
In [`github/linguist#3818`](https://github.com/github/linguist/pull/3818#discussion_r138090888), I recommended the VSCode grammar use a `scopeName` of `scope.ballerina`, rather than `scope.bal` (which has a larger risk of conflicting with future additions).

To keep the different grammar repositories synchronised, I've updated the Atom package's `scopeName` to match the one used by VSCode.